### PR TITLE
Remove circular dependency between locale and encoding

### DIFF
--- a/locales/D1885.tex
+++ b/locales/D1885.tex
@@ -311,10 +311,7 @@ struct text_encoding {
     
     static text_encoding system();
     static text_encoding wide_system();
-    
-    static text_encoding for_locale(const std::locale&);
-    static text_encoding wide_for_locale(const std::locale&);
-    
+
     private:
         int mib_; // \expos
         std::string name_; // \expos
@@ -464,41 +461,63 @@ This function should always during the same value during the lifetime of a progr
 
 \end{addedblock}
 
-In \tcode{<locale>}:
+In \tcode{[locale]}:
 
 \begin{quote}
-\begin{addedblock}
-
 \begin{codeblock}
-
 namespace std {
-    text_encoding text_encoding_for_locale(const std::locale&);
-    text_encoding text_encoding_wide_for_locale(const std::locale&);
-}
+  class locale {
+  public:
+    [...]
 
+    // locale operations
+    string name() const;
+\end{codeblock}
+\begin{addedblock}
+\begin{codeblock}
+    text_encoding encoding() const;
+    text_encoding wide_encoding() const;
 \end{codeblock}
 \end{addedblock}
+\begin{codeblock}
+  };
+}
+\end{codeblock}
 \end{quote}
 
-\begin{addedblock}
+In \tcode{[locale.members]}:
 
 \begin{itemdecl}
-text_encoding text_encoding_for_locale(const std::locale& loc);
+string name() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-    \returns The text encoding for narrow string associated with the locale \tcode{loc}.
+\pnum
+\returns
+The name of
+\tcode{*this},
+if it has one; otherwise, the string \tcode{"*"}.
+\end{itemdescr}
+
+\begin{addedblock}
+\begin{itemdecl}
+text_encoding encoding() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \returns The text encoding for narrow strings associated with the locale
+  \tcode{*this}.
 \end{itemdescr}
 
 \begin{itemdecl}
-text_encoding text_encoding_wide_for_locale(const std::locale& loc);
+text_encoding wide_encoding() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-    \returns The text encoding for wide strings associated with the locale \tcode{loc}
+  \returns The text encoding for wide strings associated with the locale
+  \tcode{*this}.
 \end{itemdescr}
 \end{addedblock}
-
 
 \section{Acknowledgments}
 


### PR DESCRIPTION
The proposed change removes dependency of encoding on locale because encoding is a more fundamental API and we shouldn't pull in the locale just to use it.

It also replaces `text_encoding_for_locale` and `text_encoding_wide_for_locale` free functions with `locale` members `encoding` and `wide_encoding` respectively which is more consistent with both the locale API and the rest of P1885 creating a nice symmetry:

```
encoding::literal()
encoding::wide_literal()
```

```
encoding::system()
encoding::wide_system()
```

```
locale::encoding()
locale::wide_encoding()
```
