### PR TITLE
Fix formatter specializations

### DIFF
--- a/src/D2693.tex
+++ b/src/D2693.tex
@@ -172,7 +172,7 @@ namespace std {
 \begin{addedblock}
 \begin{codeblock}
     // \ref{stacktrace.format}, formatting support
-    struct formatter<stacktrace_entry>;
+    template<> struct formatter<stacktrace_entry>;
     template<class Allocator> struct formatter<basic_stacktrace<Allocator>>;
 \end{codeblock}
 \end{addedblock}
@@ -208,7 +208,7 @@ namespace std {
 \rSec3[stacktrace.format]{Formatting support}
 
 \begin{itemdecl}
-struct formatter<stacktrace_entry>;
+template <> struct formatter<stacktrace_entry>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -220,8 +220,7 @@ A \tcode{stacktrace_entry} object is formatted as if by passing it to \tcode{to_
 
 
 \begin{itemdecl}
-template<class Allocator>
-struct formatter<basic_stacktrace<Allocator>>;
+template<class Allocator> struct formatter<basic_stacktrace<Allocator>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -335,8 +334,7 @@ The library may reuse the value of a \tcode{thread::id} of a terminated thread t
 \begin{addedblock}
 
 \begin{itemdecl}
-template<class charT>
-class formatter<thread::id, charT>;
+template<class charT> class formatter<thread::id, charT>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Add missing `template<>` and apply minor formatting fixes.